### PR TITLE
Enable Syncronize action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added support for `Syncronize` action in `pull_request` webhooks. This will allow the status check to be added to every push
+
 ## 1.1.1 - *2020-10-25*
 
 - Added a changelog to track changes

--- a/lib/labelvalidator.rb
+++ b/lib/labelvalidator.rb
@@ -17,7 +17,7 @@ post '/handler' do
 
   case request.env['HTTP_X_GITHUB_EVENT']
   when 'pull_request'
-    if %w[labeled unlabeled opened reopened].include?(payload['action'])
+    if %w[labeled unlabeled opened reopened synchronize].include?(payload['action'])
       labels = LabelValidator::Labels.new(pull_request: payload['pull_request'])
       vcs = LabelValidator::Vcs.new(token: ENV['GITHUB_TOKEN'], pull_request: payload['pull_request'])
       return 'Only runs on Default branch' unless vcs.default_branch_target?


### PR DESCRIPTION
# Description

 Added support for `Syncronize` action in `pull_request` webhooks. This will allow the status check to be added to every push 

## Issues Resolved

closes #6 

## Check List

- [ ] All tests pass
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the CHANGELOG
- [ ] New functionality has been documented in the README if applicable
